### PR TITLE
Fix version display by correcting data file reference casing

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,8 +3,8 @@ layout: default
 title: Download On Demand GIS Add-In Tool
 ---
 
-{% assign prod_version = site.data.version_production.latest %}
-{% assign test_version = site.data.version_test.latest %}
+{% assign prod_version = site.data.version_Production.latest %}
+{% assign test_version = site.data.version_Test.latest %}
 {% assign vprod = 'v' | append: prod_version %}
 {% assign vtest = 'v' | append: test_version %}
 


### PR DESCRIPTION
Updated index.md to reference version_Production and version_Test with proper casing to match the actual data files created by the publish workflow. This fixes the issue where version numbers were not populating in download URLs and button labels on the GitHub Pages site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)